### PR TITLE
fix: correct 'requets' to 'request' typo in server/main.py

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -222,10 +222,10 @@ connectProxy(apiApp)
 debugApp = FastAPI()
 
 @debugApp.get("/")
-async def hello(requets: Request):
-    client = requets.client
-    headers = requets.headers
-    cookies = requets.cookies
+async def hello(request: Request):
+    client = request.client
+    headers = request.headers
+    cookies = request.cookies
     import aiohttp
     import jwt
     bearer = cookies.get("authorization")


### PR DESCRIPTION
## Summary
Corrects 'requets' → 'request' typo in `server/main.py` line 225.

The FastAPI endpoint function parameter was misspelled as 'requets' instead of 'request', causing the variable to be used incorrectly throughout the function.

Fixes #13

## Changes
- 1 file, 4 lines changed (all4 occurrences of 'requets' → 'request')
- Single commit, GH007 compliant